### PR TITLE
exif情報に基づいて自動に画像を回転できるようになった

### DIFF
--- a/star_face_similarity/main.py
+++ b/star_face_similarity/main.py
@@ -5,7 +5,7 @@ import numpy as np
 from PIL import Image
 import face_recognition
 
-from star_face_similarity.utils import load_data_csv
+from star_face_similarity.utils import load_data_csv, rotateImage
 
 
 class StarFaceSimilarity:
@@ -18,7 +18,18 @@ class StarFaceSimilarity:
 
     def _transform_bytes_image_to_RGB_ndarray(self, bytes):
         image = Image.open(io.BytesIO(bytes))
-        image.convert('RGB')
+
+        try:
+            # exif情報取得
+            exifinfo = image._getexif()
+            # exif情報からOrientationの取得
+            orientation = exifinfo.get(0x112, 1)
+            # 画像を回転
+            image = rotateImage(image, orientation)
+
+        except Exception as e:
+            print(e)
+
         image = np.array(image)
         return image
 

--- a/star_face_similarity/utils.py
+++ b/star_face_similarity/utils.py
@@ -6,6 +6,7 @@ from typing import List, Tuple
 import json
 import requests
 import numpy as np
+from PIL import Image
 from pydantic import BaseModel
 
 
@@ -83,6 +84,44 @@ def find_all_file(path: str):
             file_list.append(file_path)
 
     return file_list
+
+
+def rotateImage(img: Image.Image, orientation):
+    """
+    The source of this code is as follows. Some changes have been made compared to the source.
+    source:https://max999blog.com/python-rotate-image-by-exif-orientation/
+
+    画像ファイルをOrientationの値に応じて回転させる
+    """
+    img_rotate = img
+    # orientationの値に応じて画像を回転させる
+    if orientation == 1:
+        pass
+    elif orientation == 2:
+        # 左右反転
+        img_rotate = img.transpose(Image.FLIP_LEFT_RIGHT)
+    elif orientation == 3:
+        # 180度回転
+        img_rotate = img.transpose(Image.ROTATE_180)
+    elif orientation == 4:
+        # 上下反転
+        img_rotate = img.transpose(Image.FLIP_TOP_BOTTOM)
+    elif orientation == 5:
+        # 左右反転して90度回転
+        img_rotate = img.transpose(Image.FLIP_LEFT_RIGHT).transpose(Image.ROTATE_90)
+    elif orientation == 6:
+        # 270度回転
+        img_rotate = img.transpose(Image.ROTATE_270)
+    elif orientation == 7:
+        # 左右反転して270度回転
+        img_rotate = img.transpose(Image.FLIP_LEFT_RIGHT).transpose(Image.ROTATE_270)
+    elif orientation == 8:
+        # 90度回転
+        img_rotate = img.transpose(Image.ROTATE_90)
+    else:
+        pass
+
+    return img_rotate
 
 
 def save_image_json(face_names: list, face_encoding: List[np.ndarray], file_path: str):


### PR DESCRIPTION
スマホからの精度が低いのは画像が正しい向きじゃないのが原因

スマホで撮った画像はデバイスの向きをexifのorientationに保存している。大抵のソフトは画像はexifのorientationに基ついて画像を回転しれくれるが、Pillowはしてくれません。

このプルリクでexifのorientationに基づいて回転できるようになる